### PR TITLE
Add log file option for server logging

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -75,8 +75,8 @@ logging.basicConfig(
 )
 ```
 To send logs to a file instead, run the server with `--log-file <path>` or set the
-`MCP_LOG_FILE` environment variable. Logs from FastMCP, Uvicorn, and other
-dependencies will also be written to the configured file.
+`MCP_LOG_FILE` environment variable. Logs from FastMCP will also be written to the
+configured file.
 
 ### Run the Development Server
 

--- a/src/README.md
+++ b/src/README.md
@@ -74,6 +74,8 @@ logging.basicConfig(
     stream=sys.stderr,
 )
 ```
+To send logs to a file instead, run the server with `--log-file <path>` or set the
+`MCP_LOG_FILE` environment variable.
 
 ### Run the Development Server
 

--- a/src/README.md
+++ b/src/README.md
@@ -75,7 +75,8 @@ logging.basicConfig(
 )
 ```
 To send logs to a file instead, run the server with `--log-file <path>` or set the
-`MCP_LOG_FILE` environment variable.
+`MCP_LOG_FILE` environment variable. Any logs from Uvicorn or other dependencies
+will also be written to the configured file.
 
 ### Run the Development Server
 

--- a/src/README.md
+++ b/src/README.md
@@ -75,8 +75,8 @@ logging.basicConfig(
 )
 ```
 To send logs to a file instead, run the server with `--log-file <path>` or set the
-`MCP_LOG_FILE` environment variable. Any logs from Uvicorn or other dependencies
-will also be written to the configured file.
+`MCP_LOG_FILE` environment variable. Logs from FastMCP, Uvicorn, and other
+dependencies will also be written to the configured file.
 
 ### Run the Development Server
 

--- a/src/mcp_panther/server.py
+++ b/src/mcp_panther/server.py
@@ -22,7 +22,11 @@ log_level = getattr(logging, log_level_name.upper(), logging.DEBUG)
 
 # Configure logging
 def configure_logging(log_file: str | None = None, *, force: bool = False) -> None:
-    """Configure logging to stderr or the specified file."""
+    """Configure logging to stderr or the specified file.
+
+    This also reconfigures the ``FastMCP`` logger so that all FastMCP output
+    uses the same handler as the rest of the application.
+    """
 
     handler: logging.Handler
     if log_file:
@@ -36,6 +40,13 @@ def configure_logging(log_file: str | None = None, *, force: bool = False) -> No
         handlers=[handler],
         force=force,
     )
+
+    # Ensure FastMCP logs propagate to the root logger
+    fastmcp_logger = logging.getLogger("FastMCP")
+    for hdlr in list(fastmcp_logger.handlers):
+        fastmcp_logger.removeHandler(hdlr)
+    fastmcp_logger.propagate = True
+    fastmcp_logger.setLevel(log_level)
 
 
 configure_logging(os.environ.get("MCP_LOG_FILE"))

--- a/src/mcp_panther/server.py
+++ b/src/mcp_panther/server.py
@@ -136,15 +136,7 @@ def main(transport: str, port: int, host: str, log_file: str | None):
 
         logger.info(f"Starting Panther MCP Server with SSE transport on {host}:{port}")
         # Use Uvicorn's Config and Server classes for more control
-        # Disable Uvicorn's own logging configuration so we keep our handlers
-        config = uvicorn.Config(
-            app,
-            host=host,
-            port=port,
-            timeout_graceful_shutdown=1,
-            log_config=None,
-            log_level=log_level,
-        )
+        config = uvicorn.Config(app, host=host, port=port, timeout_graceful_shutdown=1)
         server = uvicorn.Server(config)
 
         # Override the default behavior

--- a/src/mcp_panther/server.py
+++ b/src/mcp_panther/server.py
@@ -125,7 +125,15 @@ def main(transport: str, port: int, host: str, log_file: str | None):
 
         logger.info(f"Starting Panther MCP Server with SSE transport on {host}:{port}")
         # Use Uvicorn's Config and Server classes for more control
-        config = uvicorn.Config(app, host=host, port=port, timeout_graceful_shutdown=1)
+        # Disable Uvicorn's own logging configuration so we keep our handlers
+        config = uvicorn.Config(
+            app,
+            host=host,
+            port=port,
+            timeout_graceful_shutdown=1,
+            log_config=None,
+            log_level=log_level,
+        )
         server = uvicorn.Server(config)
 
         # Override the default behavior

--- a/src/mcp_panther/server.py
+++ b/src/mcp_panther/server.py
@@ -19,12 +19,26 @@ log_level_name = os.environ.get("LOG_LEVEL", "WARNING")
 # Convert string log level to logging constant
 log_level = getattr(logging, log_level_name.upper(), logging.DEBUG)
 
-# Configure logging with more detail
-logging.basicConfig(
-    level=log_level,
-    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-    stream=sys.stderr,
-)
+
+# Configure logging
+def configure_logging(log_file: str | None = None, *, force: bool = False) -> None:
+    """Configure logging to stderr or the specified file."""
+
+    handler: logging.Handler
+    if log_file:
+        handler = logging.FileHandler(log_file)
+    else:
+        handler = logging.StreamHandler(sys.stderr)
+
+    logging.basicConfig(
+        level=log_level,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        handlers=[handler],
+        force=force,
+    )
+
+
+configure_logging(os.environ.get("MCP_LOG_FILE"))
 logger = logging.getLogger(MCP_SERVER_NAME)
 
 # Support multiple import paths to accommodate different execution contexts:
@@ -85,10 +99,20 @@ def handle_signals():
     default=os.environ.get("MCP_HOST", default="127.0.0.1"),
     help="Host to bind to for SSE transport",
 )
-def main(transport: str, port: int, host: str):
+@click.option(
+    "--log-file",
+    type=click.Path(),
+    default=os.environ.get("MCP_LOG_FILE"),
+    help="Write logs to this file instead of stderr",
+)
+def main(transport: str, port: int, host: str, log_file: str | None):
     """Run the Panther MCP server with the specified transport"""
     # Set up signal handling
     handle_signals()
+
+    # Reconfigure logging if a log file is provided
+    if log_file:
+        configure_logging(log_file, force=True)
 
     if transport == "sse":
         # Create the Starlette app

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -8,9 +8,13 @@ def test_configure_logging_file(tmp_path):
     configure_logging(str(log_file), force=True)
     logger.setLevel(logging.INFO)
     logger.info("test message")
+    fast_logger = logging.getLogger("FastMCP.test")
+    fast_logger.setLevel(logging.INFO)
+    fast_logger.info("fast message")
     logging.shutdown()
     data = log_file.read_text()
     assert "test message" in data
+    assert "fast message" in data
     # reset to stderr to avoid side effects
     configure_logging(force=True)
     logger.setLevel(logging.WARNING)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,16 @@
+import logging
+
+from mcp_panther.server import configure_logging, logger
+
+
+def test_configure_logging_file(tmp_path):
+    log_file = tmp_path / "out.log"
+    configure_logging(str(log_file), force=True)
+    logger.setLevel(logging.INFO)
+    logger.info("test message")
+    logging.shutdown()
+    data = log_file.read_text()
+    assert "test message" in data
+    # reset to stderr to avoid side effects
+    configure_logging(force=True)
+    logger.setLevel(logging.WARNING)


### PR DESCRIPTION
## Summary
- add `configure_logging` helper and allow specifying a log file
- document new `--log-file`/`MCP_LOG_FILE` option in README
- test logging to a file

## Testing
- `make fmt`
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_683f82a2f57c8332a1d090e8e8b7416c